### PR TITLE
Extend battery simulation horizon and relay logic

### DIFF
--- a/client/src/components/battery-simulator.tsx
+++ b/client/src/components/battery-simulator.tsx
@@ -11,20 +11,19 @@ import { controlCycle } from "@/lib/optimization-algorithm";
 
 export function BatterySimulator() {
   const [config, setConfig] = useState<BatteryConfig>(batteryConfigSchema.parse({}));
-  const [simulationData, setSimulationData] = useState<SimulationDataPoint[]>(() => 
-    generateFixedSimulationData(batteryConfigSchema.parse({}).initialSoc)
-  );
-  const [currentSlot, setCurrentSlot] = useState(47); // Show all data
+  const initialData = generateFixedSimulationData(batteryConfigSchema.parse({}).initialSoc);
+  const [simulationData, setSimulationData] = useState<SimulationDataPoint[]>(initialData);
+  const [currentSlot, setCurrentSlot] = useState(initialData.length - 1); // Show all data
 
   const [totalCost, setTotalCost] = useState(0);
 
 
 
   const runFullSimulation = () => {
-    setCurrentSlot(47);
-    setTotalCost(0);
-    
     const data = generateFixedSimulationData(config.initialSoc);
+    setCurrentSlot(data.length - 1);
+    setTotalCost(0);
+
     const optimizedData = [...data];
     let totalCostAccumulator = 0;
     
@@ -42,10 +41,10 @@ export function BatterySimulator() {
       current.decision = decision.decision;
       current.reason = decision.reason;
       
-      // Account for relay increasing consumption by 10kW when ON
+      // Account for relay increasing consumption by configured power when ON
       let effectiveConsumption = current.consumption;
       if (current.relayState) {
-        effectiveConsumption += 10;
+        effectiveConsumption += config.relayNominalPower;
       }
       
       // Calculate net power (positive = from grid, negative = to grid)

--- a/client/src/components/configuration-panel.tsx
+++ b/client/src/components/configuration-panel.tsx
@@ -203,6 +203,82 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
           </div>
         </CardContent>
       </Card>
+
+      <Card className="bg-gray-800 border-gray-700">
+        <CardHeader>
+          <CardTitle className="text-lg font-semibold text-gray-50">Relay Settings</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label htmlFor="relayActivationPower" className="text-sm font-medium text-gray-300">
+              Activation Power (kW)
+            </Label>
+            <Input
+              id="relayActivationPower"
+              type="number"
+              min="0"
+              value={config.relayActivationPower}
+              onChange={(e) => updateConfig('relayActivationPower', parseFloat(e.target.value))}
+              className="mt-1 bg-gray-700 border-gray-600 text-gray-50 focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <Label htmlFor="relayNominalPower" className="text-sm font-medium text-gray-300">
+              Nominal Power (kW)
+            </Label>
+            <Input
+              id="relayNominalPower"
+              type="number"
+              min="0"
+              value={config.relayNominalPower}
+              onChange={(e) => updateConfig('relayNominalPower', parseFloat(e.target.value))}
+              className="mt-1 bg-gray-700 border-gray-600 text-gray-50 focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <Label htmlFor="relayMinRuntimeActivation" className="text-sm font-medium text-gray-300">
+              Min Runtime per Activation (h)
+            </Label>
+            <Input
+              id="relayMinRuntimeActivation"
+              type="number"
+              min="0"
+              step="0.25"
+              value={config.relayMinRuntimeActivation}
+              onChange={(e) => updateConfig('relayMinRuntimeActivation', parseFloat(e.target.value))}
+              className="mt-1 bg-gray-700 border-gray-600 text-gray-50 focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <Label htmlFor="relayMinRuntimeDaily" className="text-sm font-medium text-gray-300">
+              Min Runtime per Day (h)
+            </Label>
+            <Input
+              id="relayMinRuntimeDaily"
+              type="number"
+              min="0"
+              step="0.25"
+              value={config.relayMinRuntimeDaily}
+              onChange={(e) => updateConfig('relayMinRuntimeDaily', parseFloat(e.target.value))}
+              className="mt-1 bg-gray-700 border-gray-600 text-gray-50 focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <Label htmlFor="relayRuntimeDeadlineHour" className="text-sm font-medium text-gray-300">
+              Runtime Deadline Hour
+            </Label>
+            <Input
+              id="relayRuntimeDeadlineHour"
+              type="number"
+              min="0"
+              max="23"
+              value={config.relayRuntimeDeadlineHour}
+              onChange={(e) => updateConfig('relayRuntimeDeadlineHour', parseFloat(e.target.value))}
+              className="mt-1 bg-gray-700 border-gray-600 text-gray-50 focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/client/src/lib/fixed-data.ts
+++ b/client/src/lib/fixed-data.ts
@@ -3,6 +3,14 @@ import { SimulationDataPoint } from "@shared/schema";
 // Fixed data that won't change when configuration is adjusted
 export const FIXED_SIMULATION_DATA = {
   prices: {
+    0: { injection: 0.050, consumption: 0.150 },
+    1: { injection: 0.045, consumption: 0.140 },
+    2: { injection: 0.040, consumption: 0.130 },
+    3: { injection: 0.035, consumption: 0.120 },
+    4: { injection: 0.030, consumption: 0.110 },
+    5: { injection: 0.025, consumption: 0.105 },
+    6: { injection: -0.125, consumption: -0.016 },
+    7: { injection: -0.115, consumption: -0.006 },
     8: { injection: 0.050, consumption: 0.150 },
     9: { injection: 0.045, consumption: 0.140 },
     10: { injection: 0.040, consumption: 0.130 },
@@ -54,22 +62,22 @@ export function generateFixedSimulationData(initialSoc: number): SimulationDataP
   const startTime = new Date();
   startTime.setHours(8, 0, 0, 0); // Start at 8:00 AM
 
-  for (let i = 0; i < 48; i++) {
+  for (let i = 0; i < 96; i++) {
     const time = new Date(startTime.getTime() + i * 15 * 60 * 1000);
     const hour = time.getHours();
-    
+
     // Get fixed price data
-    const pricePair = FIXED_SIMULATION_DATA.prices[hour as keyof typeof FIXED_SIMULATION_DATA.prices] || 
+    const pricePair = FIXED_SIMULATION_DATA.prices[hour as keyof typeof FIXED_SIMULATION_DATA.prices] ||
                       { injection: 0.050, consumption: 0.150 };
-    
+
     data.push({
       time,
       timeString: time.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' }),
       injectionPrice: pricePair.injection,
       consumptionPrice: pricePair.consumption,
-      consumption: FIXED_SIMULATION_DATA.consumption[i],
-      pvGeneration: FIXED_SIMULATION_DATA.pvGeneration[i],
-      pvForecast: FIXED_SIMULATION_DATA.pvForecast[i],
+      consumption: FIXED_SIMULATION_DATA.consumption[i % 48],
+      pvGeneration: FIXED_SIMULATION_DATA.pvGeneration[i % 48],
+      pvForecast: FIXED_SIMULATION_DATA.pvForecast[i % 48],
       batteryPower: 0,
       soc: initialSoc,
       netPower: 0,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -9,6 +9,11 @@ export const batteryConfigSchema = z.object({
   minSoc: z.number().min(0).max(100).default(5),
   maxSoc: z.number().min(0).max(100).default(95),
   relayConsumption: z.number().min(0).default(10),
+  relayMinRuntimeActivation: z.number().min(0).default(0.5),
+  relayMinRuntimeDaily: z.number().min(0).default(2),
+  relayRuntimeDeadlineHour: z.number().min(0).max(23).default(20),
+  relayActivationPower: z.number().min(0).default(5),
+  relayNominalPower: z.number().min(0).default(10),
 });
 
 // Simulation Data Point Schema


### PR DESCRIPTION
## Summary
- allow configuration of relay runtime, power and activation logic
- preload simulation data for a 24h horizon
- expand default simulation dataset and prediction horizon
- update UI to manage new relay settings

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687803040f8483329fabe356dbfdba4d