### PR TITLE
Update discharge reserve logic

### DIFF
--- a/client/src/lib/optimization-algorithm.ts
+++ b/client/src/lib/optimization-algorithm.ts
@@ -33,7 +33,14 @@ export function controlCycle(
   }
   // Discharging logic
   else {
-    const dischargeDecision = shouldDischargeNow(currentSlot, mostExpensiveSlots, current, config, decision.relayState);
+    const dischargeDecision = shouldDischargeNow(
+      currentSlot,
+      mostExpensiveSlots,
+      current,
+      config,
+      decision.relayState,
+      forecast
+    );
     if (dischargeDecision.power > 0) {
       decision.batteryPower = -dischargeDecision.power;
       decision.decision = 'discharge';
@@ -49,8 +56,12 @@ export function controlCycle(
   decision.relayState = (pvOverproduction > 0 && current.soc >= config.maxSoc) ||
                         (current.consumptionPrice <= 0);
 
-  // PV Curtailment Logic - curtail only excess to reach 0kW net consumption
-  if (current.injectionPrice < 0) {
+  // PV Curtailment Logic
+  if (current.consumptionPrice < 0) {
+    // Negative consumption price: curtail all PV to maximize grid offtake
+    decision.curtailment = current.pvGeneration;
+  } else if (current.injectionPrice < 0) {
+    // Negative injection price: only curtail excess to avoid injecting
     let effectiveConsumption = current.consumption + decision.batteryPower;
     if (decision.relayState) {
       effectiveConsumption += config.relayConsumption;
@@ -160,7 +171,8 @@ function shouldDischargeNow(
   mostExpensiveSlots: number[],
   current: SimulationDataPoint,
   config: BatteryConfig,
-  relayState: boolean
+  relayState: boolean,
+  forecast: SimulationDataPoint[]
 ): { power: number; reason: string } {
   if (!mostExpensiveSlots.includes(currentSlot)) {
     return { power: 0, reason: 'not expensive slot' };
@@ -183,6 +195,25 @@ function shouldDischargeNow(
     return { power: 0, reason: 'no deficit to cover' };
   }
 
-  // Only discharge what's actually needed, up to max discharge rate
-  return { power: Math.min(deficit, config.maxDischargeRate), reason: 'cover consumption' };
+  // Determine energy that must remain for upcoming expensive consumption
+  const futureNeed = forecast.slice(1, 13).reduce((sum, slot) => {
+    if (slot.consumptionPrice > current.injectionPrice) {
+      const d = Math.max(0, slot.consumption - slot.pvForecast);
+      return sum + d * 0.25;
+    }
+    return sum;
+  }, 0);
+
+  const socEnergy = (current.soc / 100) * config.batteryCapacity;
+  const minEnergy = (config.minSoc / 100) * config.batteryCapacity;
+  const allowedEnergy = socEnergy - minEnergy - futureNeed;
+
+  const maxPower = Math.min(deficit, config.maxDischargeRate, allowedEnergy / 0.25);
+
+  if (maxPower <= 0) {
+    return { power: 0, reason: 'reserve for future expensive consumption' };
+  }
+
+  // Only discharge what's actually needed, up to allowed power
+  return { power: maxPower, reason: 'cover consumption' };
 }


### PR DESCRIPTION
## Summary
- reserve energy for future expensive consumption when discharging
- fully curtail PV generation whenever the consumption price is negative

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68780bc3369883329d432e4edd6604ed