### PR TITLE
Add scenario options and rename simulator

### DIFF
--- a/client/src/components/charts-section.tsx
+++ b/client/src/components/charts-section.tsx
@@ -2,12 +2,15 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SimulationDataPoint } from "@shared/schema";
 import { useEffect, useRef } from "react";
 
+import { BatteryConfig } from "@shared/schema";
+
 interface ChartsSectionProps {
   data: SimulationDataPoint[];
   currentSlot: number;
+  config: BatteryConfig;
 }
 
-export function ChartsSection({ data, currentSlot }: ChartsSectionProps) {
+export function ChartsSection({ data, currentSlot, config }: ChartsSectionProps) {
   const mainChartRef = useRef<HTMLCanvasElement>(null);
   const socChartRef = useRef<HTMLCanvasElement>(null);
   const mainChartInstance = useRef<any>(null);
@@ -40,6 +43,14 @@ export function ChartsSection({ data, currentSlot }: ChartsSectionProps) {
       if (socChart && socChart.data && socChart.data.datasets && socChart.data.datasets.length >= 1) {
         socChart.data.labels = labels;
         socChart.data.datasets[0].data = soc;
+        if (socChart.options.plugins && (socChart.options as any).plugins.annotation) {
+          (socChart.options as any).plugins.annotation.annotations.minSocLine.yMin = config.minSoc;
+          (socChart.options as any).plugins.annotation.annotations.minSocLine.yMax = config.minSoc;
+          (socChart.options as any).plugins.annotation.annotations.minSocLine.label.content = `Min SoC (${config.minSoc}%)`;
+          (socChart.options as any).plugins.annotation.annotations.maxSocLine.yMin = config.maxSoc;
+          (socChart.options as any).plugins.annotation.annotations.maxSocLine.yMax = config.maxSoc;
+          (socChart.options as any).plugins.annotation.annotations.maxSocLine.label.content = `Max SoC (${config.maxSoc}%)`;
+        }
         socChart.update('none');
       }
     }
@@ -224,13 +235,13 @@ export function ChartsSection({ data, currentSlot }: ChartsSectionProps) {
                   annotations: {
                     minSocLine: {
                       type: 'line',
-                      yMin: 5,
-                      yMax: 5,
+                      yMin: config.minSoc,
+                      yMax: config.minSoc,
                       borderColor: '#EF4444',
                       borderWidth: 2,
                       borderDash: [5, 5],
                       label: {
-                        content: 'Min SoC (5%)',
+                        content: `Min SoC (${config.minSoc}%)`,
                         enabled: true,
                         position: 'start',
                         color: '#EF4444',
@@ -246,13 +257,13 @@ export function ChartsSection({ data, currentSlot }: ChartsSectionProps) {
                     },
                     maxSocLine: {
                       type: 'line',
-                      yMin: 95,
-                      yMax: 95,
+                      yMin: config.maxSoc,
+                      yMax: config.maxSoc,
                       borderColor: '#10B981',
                       borderWidth: 2,
                       borderDash: [5, 5],
                       label: {
-                        content: 'Max SoC (95%)',
+                        content: `Max SoC (${config.maxSoc}%)`,
                         enabled: true,
                         position: 'start',
                         color: '#10B981',

--- a/client/src/components/configuration-panel.tsx
+++ b/client/src/components/configuration-panel.tsx
@@ -5,12 +5,16 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { Info } from "lucide-react";
 import { BatteryConfig } from "@shared/schema";
 
+import { SimulationScenario } from "@/lib/data-generator";
+
 interface ConfigurationPanelProps {
   config: BatteryConfig;
   onConfigChange: (config: BatteryConfig) => void;
+  scenario: SimulationScenario;
+  onScenarioChange: (s: SimulationScenario) => void;
 }
 
-export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPanelProps) {
+export function ConfigurationPanel({ config, onConfigChange, scenario, onScenarioChange }: ConfigurationPanelProps) {
   const updateConfig = (field: keyof BatteryConfig, value: number) => {
     onConfigChange({
       ...config,
@@ -20,6 +24,25 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
 
   return (
     <div className="space-y-6">
+      <Card className="bg-gray-800 border-gray-700">
+        <CardHeader>
+          <CardTitle className="text-lg font-semibold text-gray-50">Scenario</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <select
+            className="mt-1 bg-gray-700 border-gray-600 text-gray-50 w-full"
+            value={scenario}
+            onChange={e => onScenarioChange(e.target.value as SimulationScenario)}
+          >
+            <option value="eveningHighPrice">Evening high prices</option>
+            <option value="negativeDayPrice">Negative day prices</option>
+            <option value="variablePv">Variable PV</option>
+            <option value="startupPeak">Workday startup peak</option>
+            <option value="lowPv">Low PV yield</option>
+            <option value="random">Random</option>
+          </select>
+        </CardContent>
+      </Card>
       <Card className="bg-gray-800 border-gray-700">
         <CardHeader>
           <CardTitle className="text-lg font-semibold text-gray-50">Battery Configuration</CardTitle>

--- a/client/src/components/data-table.tsx
+++ b/client/src/components/data-table.tsx
@@ -58,7 +58,7 @@ export function DataTable({ data, currentSlot, onClearLog, onExportData }: DataT
                   <td className="py-2 text-purple-400">{row.soc.toFixed(1)}</td>
                   <td className="py-2 text-cyan-400" title={row.batteryDecisionReason}>{row.batteryDecision || 'hold'}</td>
                   <td className="py-2 text-orange-400">{row.loadState ? 'ON' : 'OFF'}</td>
-                  <td className="py-2 text-pink-400">{row.pvCurtailment?.toFixed(1) || '0.0'}</td>
+                  <td className="py-2 text-pink-400">{row.curtailment?.toFixed(1) || '0.0'}</td>
                   <td className="py-2 text-gray-300">{row.netPower.toFixed(1)}</td>
                   <td className="py-2 text-gray-300">€{row.cost.toFixed(3)}</td>
                 </tr>

--- a/client/src/components/editable-data-table.tsx
+++ b/client/src/components/editable-data-table.tsx
@@ -183,7 +183,7 @@ export function EditableDataTable({
                   <td className="py-2 text-purple-400">{row.soc.toFixed(1)}</td>
                   <td className="py-2 text-cyan-400" title={row.batteryDecisionReason}>{row.batteryDecision || 'hold'}</td>
                   <td className="py-2 text-orange-400">{row.loadState ? 'ON' : 'OFF'}</td>
-                  <td className="py-2 text-pink-400">{row.pvCurtailment?.toFixed(1) || '0.0'}</td>
+                  <td className="py-2 text-pink-400">{row.curtailment?.toFixed(1) || '0.0'}</td>
                   <td className="py-2 text-gray-300">{row.netPower.toFixed(1)}</td>
                   <td className="py-2 text-gray-300">€{row.cost.toFixed(3)}</td>
                 </tr>

--- a/client/src/lib/fixed-data.ts
+++ b/client/src/lib/fixed-data.ts
@@ -89,7 +89,7 @@ export function generateFixedSimulationData(
       soc: initialSoc,
       netPower: 0,
       cost: 0,
-      pvCurtailment: 0,
+      curtailment: 0,
       loadState: false,
       batteryDecision: 'hold',
       batteryDecisionReason: '',

--- a/client/src/lib/optimization-algorithm.ts
+++ b/client/src/lib/optimization-algorithm.ts
@@ -18,7 +18,7 @@ export function controlCycle(
 
   let decision: ControlDecision = {
     batteryPower: 0,
-    pvCurtailment: 0,
+    curtailment: 0,
     loadState: false,
     batteryDecision: 'hold',
     batteryDecisionReason: '',
@@ -55,7 +55,7 @@ export function controlCycle(
   decision.loadState = determineLoadState(currentSlot, data, decision.batteryPower, config, current);
 
   // PV curtailment logic
-  decision.pvCurtailment = calculatePvCurtailment(current, decision, config);
+  decision.curtailment = calculatePvCurtailment(current, decision, config);
 
   return decision;
 }

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,5 +1,5 @@
-import { BatterySimulator } from "@/components/battery-simulator";
+import { EnergyFlowSimulator } from "@/components/energy-flow-simulator";
 
 export default function Home() {
-  return <BatterySimulator />;
+  return <EnergyFlowSimulator />;
 }

--- a/replit.md
+++ b/replit.md
@@ -49,7 +49,7 @@ Preferred communication style: Simple, everyday language.
 
 ### Key Components
 
-#### Battery Simulator (`client/src/components/battery-simulator.tsx`)
+#### Energy Flow Simulator (`client/src/components/energy-flow-simulator.tsx`)
 - Main simulation controller with real-time updates
 - Manages battery state, pricing, and energy flow
 - Integrates optimization algorithm for charge/discharge decisions
@@ -80,7 +80,7 @@ Preferred communication style: Simple, everyday language.
 ### Data Flow
 
 1. **Configuration**: User sets battery parameters through Configuration Panel
-2. **Simulation Start**: Battery Simulator generates 48 time slots of mock data (prices, consumption, PV)
+2. **Simulation Start**: Energy Flow Simulator generates 48 time slots of mock data (prices, consumption, PV)
 3. **Optimization**: Control algorithm analyzes current state and price forecast
 4. **Decision Making**: System determines optimal battery power for each time slot
 5. **Visualization**: Charts and tables update in real-time showing energy flows and costs

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -28,7 +28,7 @@ export const simulationDataPointSchema = z.object({
   soc: z.number(),
   netPower: z.number(),
   cost: z.number(),
-  pvCurtailment: z.number().default(0),
+  curtailment: z.number().default(0),
   loadState: z.boolean().default(false),
   batteryDecision: z.string().default('hold'),
   batteryDecisionReason: z.string().default(''),
@@ -37,7 +37,7 @@ export const simulationDataPointSchema = z.object({
 // Control Decision Schema
 export const controlDecisionSchema = z.object({
   batteryPower: z.number(),
-  pvCurtailment: z.number().default(0),
+  curtailment: z.number().default(0),
   loadState: z.boolean().default(false),
   batteryDecision: z.string().default('hold'),
   batteryDecisionReason: z.string().default(''),


### PR DESCRIPTION
## Summary
- rename `battery-simulator` to `energy-flow-simulator`
- rename `pvCurtailment` field to `curtailment`
- add scenario generation utilities
- allow scenario choice in the configuration panel
- update charts to honour SoC limits
- adjust docs accordingly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687901bca7188332beddd8819e4cd22c