### PR TITLE
Add collapsible forms and net power chart

### DIFF
--- a/client/src/components/charts-section.tsx
+++ b/client/src/components/charts-section.tsx
@@ -13,8 +13,10 @@ interface ChartsSectionProps {
 export function ChartsSection({ data, currentSlot, config }: ChartsSectionProps) {
   const mainChartRef = useRef<HTMLCanvasElement>(null);
   const socChartRef = useRef<HTMLCanvasElement>(null);
+  const netChartRef = useRef<HTMLCanvasElement>(null);
   const mainChartInstance = useRef<any>(null);
   const socChartInstance = useRef<any>(null);
+  const netChartInstance = useRef<any>(null);
 
   const updateCharts = () => {
     if (mainChartInstance.current && socChartInstance.current && data.length > 0) {
@@ -26,9 +28,12 @@ export function ChartsSection({ data, currentSlot, config }: ChartsSectionProps)
       const pvForecast = visibleData.map(d => d.pvForecast || 0);
       const batteryPower = visibleData.map(d => d.batteryPower);
       const soc = visibleData.map(d => d.soc);
+      const netPower = visibleData.map(d => d.netPower);
+      const cost = visibleData.map(d => d.cost);
 
       const mainChart = mainChartInstance.current;
       const socChart = socChartInstance.current;
+      const netChart = netChartInstance.current;
 
       if (mainChart && mainChart.data && mainChart.data.datasets && mainChart.data.datasets.length >= 5) {
         mainChart.data.labels = labels;
@@ -38,6 +43,13 @@ export function ChartsSection({ data, currentSlot, config }: ChartsSectionProps)
         mainChart.data.datasets[3].data = pvForecast;
         mainChart.data.datasets[4].data = batteryPower;
         mainChart.update('none');
+      }
+
+      if (netChart && netChart.data && netChart.data.datasets && netChart.data.datasets.length >= 2) {
+        netChart.data.labels = labels;
+        netChart.data.datasets[0].data = netPower;
+        netChart.data.datasets[1].data = cost;
+        netChart.update('none');
       }
 
       if (socChart && socChart.data && socChart.data.datasets && socChart.data.datasets.length >= 1) {
@@ -305,6 +317,83 @@ export function ChartsSection({ data, currentSlot, config }: ChartsSectionProps)
         }
       }
 
+      if (netChartRef.current && !netChartInstance.current) {
+        const ctx = netChartRef.current.getContext('2d');
+        if (ctx) {
+          netChartInstance.current = new Chart(ctx, {
+            type: 'line',
+            data: {
+              labels: [],
+              datasets: [
+                {
+                  label: 'Net Power (kW)',
+                  data: [],
+                  borderColor: '#FACC15',
+                  backgroundColor: 'rgba(250, 204, 21, 0.1)',
+                  yAxisID: 'y',
+                  tension: 0.1,
+                },
+                {
+                  label: 'Cost (€)',
+                  data: [],
+                  borderColor: '#6366F1',
+                  backgroundColor: 'rgba(99, 102, 241, 0.1)',
+                  yAxisID: 'y1',
+                  tension: 0.1,
+                },
+              ],
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              interaction: { mode: 'index', intersect: false },
+              plugins: {
+                legend: { display: false },
+                tooltip: {
+                  mode: 'index',
+                  intersect: false,
+                  backgroundColor: 'rgba(31, 41, 55, 0.95)',
+                  titleColor: '#F9FAFB',
+                  bodyColor: '#F9FAFB',
+                  borderColor: '#6B7280',
+                  borderWidth: 1,
+                  callbacks: {
+                    labelColor: function(context: any) {
+                      const datasetIndex = context.datasetIndex;
+                      const colors = ['#FACC15', '#6366F1'];
+                      return {
+                        borderColor: colors[datasetIndex] || '#9CA3AF',
+                        backgroundColor: colors[datasetIndex] || '#9CA3AF',
+                      };
+                    },
+                  },
+                },
+              },
+              scales: {
+                y: {
+                  type: 'linear',
+                  display: true,
+                  position: 'left',
+                  grid: { color: 'rgba(75, 85, 99, 0.3)' },
+                  ticks: { color: '#9CA3AF' },
+                },
+                y1: {
+                  type: 'linear',
+                  display: true,
+                  position: 'right',
+                  grid: { drawOnChartArea: false },
+                  ticks: { color: '#9CA3AF' },
+                },
+                x: {
+                  grid: { color: 'rgba(75, 85, 99, 0.3)' },
+                  ticks: { color: '#9CA3AF' },
+                },
+              },
+            },
+          });
+        }
+      }
+
       updateCharts();
     };
 
@@ -365,6 +454,29 @@ export function ChartsSection({ data, currentSlot, config }: ChartsSectionProps)
         <CardContent>
           <div className="h-64 w-full">
             <canvas ref={socChartRef}></canvas>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="bg-gray-800 border-gray-700">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg font-semibold text-gray-50">Net Power & Cost</CardTitle>
+            <div className="flex items-center space-x-4">
+              <div className="flex items-center space-x-2">
+                <div className="w-3 h-3 bg-yellow-400 rounded-full"></div>
+                <span className="text-sm text-gray-300">Net Power</span>
+              </div>
+              <div className="flex items-center space-x-2">
+                <div className="w-3 h-3 bg-indigo-500 rounded-full"></div>
+                <span className="text-sm text-gray-300">Cost</span>
+              </div>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="h-64 w-full">
+            <canvas ref={netChartRef}></canvas>
           </div>
         </CardContent>
       </Card>

--- a/client/src/components/configuration-panel.tsx
+++ b/client/src/components/configuration-panel.tsx
@@ -2,7 +2,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Info } from "lucide-react";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Button } from "@/components/ui/button";
+import { Info, ChevronDown } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
 import { BatteryConfig } from "@shared/schema";
 
 import { SimulationScenario } from "@/lib/data-generator";
@@ -15,6 +19,11 @@ interface ConfigurationPanelProps {
 }
 
 export function ConfigurationPanel({ config, onConfigChange, scenario, onScenarioChange }: ConfigurationPanelProps) {
+  const [openScenario, setOpenScenario] = useState(true)
+  const [openBattery, setOpenBattery] = useState(false)
+  const [openLimits, setOpenLimits] = useState(false)
+  const [openLoad, setOpenLoad] = useState(false)
+
   const updateConfig = (field: keyof BatteryConfig, value: number) => {
     onConfigChange({
       ...config,
@@ -24,30 +33,46 @@ export function ConfigurationPanel({ config, onConfigChange, scenario, onScenari
 
   return (
     <div className="space-y-6">
-      <Card className="bg-gray-800 border-gray-700">
-        <CardHeader>
-          <CardTitle className="text-lg font-semibold text-gray-50">Scenario</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <select
-            className="mt-1 bg-gray-700 border-gray-600 text-gray-50 w-full"
-            value={scenario}
-            onChange={e => onScenarioChange(e.target.value as SimulationScenario)}
-          >
-            <option value="eveningHighPrice">Evening high prices</option>
-            <option value="negativeDayPrice">Negative day prices</option>
-            <option value="variablePv">Variable PV</option>
-            <option value="startupPeak">Workday startup peak</option>
-            <option value="lowPv">Low PV yield</option>
-            <option value="random">Random</option>
-          </select>
-        </CardContent>
-      </Card>
-      <Card className="bg-gray-800 border-gray-700">
-        <CardHeader>
-          <CardTitle className="text-lg font-semibold text-gray-50">Battery Configuration</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
+      <Collapsible open={openScenario} onOpenChange={setOpenScenario}>
+        <Card className="bg-gray-800 border-gray-700">
+          <CardHeader className="flex items-center justify-between">
+            <CardTitle className="text-lg font-semibold text-gray-50">Scenario</CardTitle>
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" size="icon" className="text-gray-400">
+                <ChevronDown className={cn("h-4 w-4 transition-transform", openScenario ? "rotate-180" : "")} />
+              </Button>
+            </CollapsibleTrigger>
+          </CardHeader>
+          <CollapsibleContent>
+            <CardContent>
+              <select
+                className="mt-1 bg-gray-700 border-gray-600 text-gray-50 w-full"
+                value={scenario}
+                onChange={e => onScenarioChange(e.target.value as SimulationScenario)}
+              >
+                <option value="eveningHighPrice">Evening high prices</option>
+                <option value="negativeDayPrice">Negative day prices</option>
+                <option value="variablePv">Variable PV</option>
+                <option value="startupPeak">Workday startup peak</option>
+                <option value="lowPv">Low PV yield</option>
+                <option value="random">Random</option>
+              </select>
+            </CardContent>
+          </CollapsibleContent>
+        </Card>
+      </Collapsible>
+      <Collapsible open={openBattery} onOpenChange={setOpenBattery}>
+        <Card className="bg-gray-800 border-gray-700">
+          <CardHeader className="flex items-center justify-between">
+            <CardTitle className="text-lg font-semibold text-gray-50">Battery Configuration</CardTitle>
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" size="icon" className="text-gray-400">
+                <ChevronDown className={cn("h-4 w-4 transition-transform", openBattery ? "rotate-180" : "")} />
+              </Button>
+            </CollapsibleTrigger>
+          </CardHeader>
+          <CollapsibleContent>
+            <CardContent className="space-y-4">
           <div>
             <div className="flex items-center space-x-2">
               <Label htmlFor="batteryCapacity" className="text-sm font-medium text-gray-300">
@@ -145,13 +170,22 @@ export function ConfigurationPanel({ config, onConfigChange, scenario, onScenari
             />
           </div>
         </CardContent>
-      </Card>
+          </CollapsibleContent>
+        </Card>
+      </Collapsible>
 
-      <Card className="bg-gray-800 border-gray-700">
-        <CardHeader>
-          <CardTitle className="text-lg font-semibold text-gray-50">Operating Limits</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
+      <Collapsible open={openLimits} onOpenChange={setOpenLimits}>
+        <Card className="bg-gray-800 border-gray-700">
+          <CardHeader className="flex items-center justify-between">
+            <CardTitle className="text-lg font-semibold text-gray-50">Operating Limits</CardTitle>
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" size="icon" className="text-gray-400">
+                <ChevronDown className={cn("h-4 w-4 transition-transform", openLimits ? "rotate-180" : "")} />
+              </Button>
+            </CollapsibleTrigger>
+          </CardHeader>
+          <CollapsibleContent>
+            <CardContent className="space-y-4">
           <div>
             <div className="flex items-center space-x-2">
               <Label htmlFor="minSoc" className="text-sm font-medium text-gray-300">
@@ -201,13 +235,22 @@ export function ConfigurationPanel({ config, onConfigChange, scenario, onScenari
             />
           </div>
         </CardContent>
-      </Card>
+          </CollapsibleContent>
+        </Card>
+      </Collapsible>
 
-      <Card className="bg-gray-800 border-gray-700">
-        <CardHeader>
-          <CardTitle className="text-lg font-semibold text-gray-50">Controllable load</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
+      <Collapsible open={openLoad} onOpenChange={setOpenLoad}>
+        <Card className="bg-gray-800 border-gray-700">
+          <CardHeader className="flex items-center justify-between">
+            <CardTitle className="text-lg font-semibold text-gray-50">Controllable load</CardTitle>
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" size="icon" className="text-gray-400">
+                <ChevronDown className={cn("h-4 w-4 transition-transform", openLoad ? "rotate-180" : "")} />
+              </Button>
+            </CollapsibleTrigger>
+          </CardHeader>
+          <CollapsibleContent>
+            <CardContent className="space-y-4">
           <div>
             <div className="flex items-center space-x-2">
               <Label htmlFor="loadActivationPower" className="text-sm font-medium text-gray-300">
@@ -327,7 +370,9 @@ export function ConfigurationPanel({ config, onConfigChange, scenario, onScenari
             />
           </div>
         </CardContent>
-      </Card>
+          </CollapsibleContent>
+        </Card>
+      </Collapsible>
     </div>
   );
 }

--- a/client/src/components/editable-data-table.tsx
+++ b/client/src/components/editable-data-table.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SimulationDataPoint } from "@shared/schema";
 import { useState } from "react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface EditableDataTableProps {
   data: SimulationDataPoint[];
@@ -181,11 +182,27 @@ export function EditableDataTable({
                   </td>
                   <td className="py-2 text-blue-400">{row.batteryPower.toFixed(1)}</td>
                   <td className="py-2 text-purple-400">{row.soc.toFixed(1)}</td>
-                  <td className="py-2 text-cyan-400" title={row.batteryDecisionReason}>{row.batteryDecision || 'hold'}</td>
+                  <td className="py-2 text-cyan-400">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="cursor-help">{row.batteryDecision || 'hold'}</span>
+                      </TooltipTrigger>
+                      <TooltipContent>{row.batteryDecisionReason}</TooltipContent>
+                    </Tooltip>
+                  </td>
                   <td className="py-2 text-orange-400">{row.loadState ? 'ON' : 'OFF'}</td>
                   <td className="py-2 text-pink-400">{row.curtailment?.toFixed(1) || '0.0'}</td>
                   <td className="py-2 text-gray-300">{row.netPower.toFixed(1)}</td>
-                  <td className="py-2 text-gray-300">€{row.cost.toFixed(3)}</td>
+                  <td className="py-2 text-gray-300">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="cursor-help">€{row.cost.toFixed(3)}</span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {`${row.netPower.toFixed(1)} kW * €${(row.netPower >= 0 ? row.consumptionPrice : row.injectionPrice).toFixed(3)} * 0.25h`}
+                      </TooltipContent>
+                    </Tooltip>
+                  </td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## Summary
- make configuration sections collapsible and closed by default
- show reason and cost calculation via tooltips
- display net power and cost chart alongside existing charts

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6879f90bede88332ab7b246a88ad878b