### PR TITLE
Improve load handling and PV charts

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,7 +18,7 @@ function Router() {
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
+      <TooltipProvider delayDuration={0}>
         <Toaster />
         <Router />
       </TooltipProvider>

--- a/client/src/components/charts-section.tsx
+++ b/client/src/components/charts-section.tsx
@@ -24,7 +24,7 @@ export function ChartsSection({ data, currentSlot, config }: ChartsSectionProps)
       const labels = visibleData.map(d => d.timeString);
       const prices = visibleData.map(d => d.consumptionPrice);
       const consumption = visibleData.map(d => d.consumption);
-      const pvGeneration = visibleData.map(d => d.pvGeneration);
+      const pvGeneration = visibleData.map(d => d.pvGeneration - d.curtailment);
       const pvForecast = visibleData.map(d => d.pvForecast || 0);
       const batteryPower = visibleData.map(d => d.batteryPower);
       const soc = visibleData.map(d => d.soc);

--- a/client/src/components/data-table.tsx
+++ b/client/src/components/data-table.tsx
@@ -41,7 +41,7 @@ export function DataTable({ data, currentSlot, onClearLog, onExportData }: DataT
                 <th className="pb-3 text-gray-300 font-medium">Battery Power (kW)</th>
                 <th className="pb-3 text-gray-300 font-medium">SoC (%)</th>
                 <th className="pb-3 text-gray-300 font-medium">Decision</th>
-                <th className="pb-3 text-gray-300 font-medium">Relay</th>
+                <th className="pb-3 text-gray-300 font-medium">Load</th>
                 <th className="pb-3 text-gray-300 font-medium">Curtailment (kW)</th>
                 <th className="pb-3 text-gray-300 font-medium">Net Power (kW)</th>
                 <th className="pb-3 text-gray-300 font-medium">Cost (€)</th>
@@ -57,7 +57,7 @@ export function DataTable({ data, currentSlot, onClearLog, onExportData }: DataT
                   <td className="py-2 text-blue-400">{row.batteryPower.toFixed(1)}</td>
                   <td className="py-2 text-purple-400">{row.soc.toFixed(1)}</td>
                   <td className="py-2 text-cyan-400" title={row.batteryDecisionReason}>{row.batteryDecision || 'hold'}</td>
-                  <td className="py-2 text-orange-400">{row.loadState ? 'ON' : 'OFF'}</td>
+                  <td className="py-2 text-orange-400" title={row.loadDecisionReason}>{row.loadState ? 'ON' : 'OFF'}</td>
                   <td className="py-2 text-pink-400">{row.curtailment?.toFixed(1) || '0.0'}</td>
                   <td className="py-2 text-gray-300">{row.netPower.toFixed(1)}</td>
                   <td className="py-2 text-gray-300">€{row.cost.toFixed(3)}</td>

--- a/client/src/components/editable-data-table.tsx
+++ b/client/src/components/editable-data-table.tsx
@@ -130,7 +130,7 @@ export function EditableDataTable({
                 <th className="pb-3 text-gray-300 font-medium">Battery Power (kW)</th>
                 <th className="pb-3 text-gray-300 font-medium">SoC (%)</th>
                 <th className="pb-3 text-gray-300 font-medium">Decision</th>
-                <th className="pb-3 text-gray-300 font-medium">Relay</th>
+                <th className="pb-3 text-gray-300 font-medium">Load</th>
                 <th className="pb-3 text-gray-300 font-medium">Curtailment (kW)</th>
                 <th className="pb-3 text-gray-300 font-medium">Net Power (kW)</th>
                 <th className="pb-3 text-gray-300 font-medium">Cost (€)</th>
@@ -190,7 +190,14 @@ export function EditableDataTable({
                       <TooltipContent>{row.batteryDecisionReason}</TooltipContent>
                     </Tooltip>
                   </td>
-                  <td className="py-2 text-orange-400">{row.loadState ? 'ON' : 'OFF'}</td>
+                  <td className="py-2 text-orange-400">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="cursor-help">{row.loadState ? 'ON' : 'OFF'}</span>
+                      </TooltipTrigger>
+                      <TooltipContent>{row.loadDecisionReason}</TooltipContent>
+                    </Tooltip>
+                  </td>
                   <td className="py-2 text-pink-400">{row.curtailment?.toFixed(1) || '0.0'}</td>
                   <td className="py-2 text-gray-300">{row.netPower.toFixed(1)}</td>
                   <td className="py-2 text-gray-300">

--- a/client/src/components/energy-flow-simulator.tsx
+++ b/client/src/components/energy-flow-simulator.tsx
@@ -39,17 +39,19 @@ export function EnergyFlowSimulator() {
       current.batteryPower = decision.batteryPower;
       current.curtailment = decision.curtailment;
       current.loadState = decision.loadState;
+      current.loadDecisionReason = decision.loadDecisionReason;
       current.batteryDecision = decision.batteryDecision;
       current.batteryDecisionReason = decision.batteryDecisionReason;
-      
+
       // Account for controllable load increasing consumption when ON
       let effectiveConsumption = current.consumption;
       if (current.loadState) {
         effectiveConsumption += config.loadNominalPower;
+        current.consumption += config.loadNominalPower;
       }
       
       // Calculate net power (positive = from grid, negative = to grid)
-      current.netPower = effectiveConsumption - current.pvGeneration + current.batteryPower;
+      current.netPower = effectiveConsumption + current.batteryPower - current.pvGeneration - current.curtailment;
       
       // Calculate cost for this interval (15 minutes = 0.25 hours)
       const pricePerKWh = current.netPower >= 0 ? current.consumptionPrice : current.injectionPrice;

--- a/client/src/lib/data-generator.ts
+++ b/client/src/lib/data-generator.ts
@@ -85,6 +85,7 @@ export function generateSimulationData(initialSoc: number, scenario: SimulationS
       cost: 0,
       curtailment: 0,
       loadState: false,
+      loadDecisionReason: '',
       batteryDecision: 'hold',
       batteryDecisionReason: '',
     });

--- a/client/src/lib/fixed-data.ts
+++ b/client/src/lib/fixed-data.ts
@@ -91,6 +91,7 @@ export function generateFixedSimulationData(
       cost: 0,
       curtailment: 0,
       loadState: false,
+      loadDecisionReason: '',
       batteryDecision: 'hold',
       batteryDecisionReason: '',
     });

--- a/client/src/lib/optimization-algorithm.ts
+++ b/client/src/lib/optimization-algorithm.ts
@@ -20,6 +20,7 @@ export function controlCycle(
     batteryPower: 0,
     curtailment: 0,
     loadState: false,
+    loadDecisionReason: '',
     batteryDecision: 'hold',
     batteryDecisionReason: '',
   };
@@ -52,7 +53,9 @@ export function controlCycle(
   }
 
   // Controllable load logic
-  decision.loadState = determineLoadState(currentSlot, data, decision.batteryPower, config, current);
+  const loadDecision = determineLoadState(currentSlot, data, decision.batteryPower, config, current);
+  decision.loadState = loadDecision.state;
+  decision.loadDecisionReason = loadDecision.reason;
 
   // PV curtailment logic
   decision.curtailment = calculatePvCurtailment(current, decision, config);
@@ -221,7 +224,7 @@ function determineLoadState(
   batteryPower: number,
   config: BatteryConfig,
   current: SimulationDataPoint
-): boolean {
+): { state: boolean; reason: string } {
   const prevLoad = currentSlot > 0 ? data[currentSlot - 1].loadState : false;
 
   let activationRuntime = 0;
@@ -243,22 +246,38 @@ function determineLoadState(
     dailyRuntime < config.loadMinRuntimeDaily;
 
   let load = prevLoad;
+  let reason = '';
   if (load) {
     activationRuntime += 0.25;
     if (activationRuntime >= config.loadMinRuntimeActivation && !needDailyRuntime) {
       if (config.loadActivationPower >= config.loadNominalPower) {
-        if (oversupply < config.loadNominalPower) load = false;
+        if (oversupply < config.loadNominalPower) {
+          load = false;
+          reason = 'pv oversupply insufficient';
+        } else {
+          reason = 'pv oversupply';
+        }
       } else {
-        if (gridImport > config.loadNominalPower - config.loadActivationPower) load = false;
+        if (gridImport > config.loadNominalPower - config.loadActivationPower) {
+          load = false;
+          reason = 'grid import too high';
+        } else {
+          reason = 'grid import low';
+        }
       }
+    } else {
+      reason = needDailyRuntime ? 'daily runtime required' : 'minimum runtime';
     }
   } else {
     if (oversupply >= config.loadActivationPower || needDailyRuntime) {
       load = true;
+      reason = needDailyRuntime ? 'daily runtime required' : 'pv oversupply';
+    } else {
+      reason = 'insufficient oversupply';
     }
   }
 
-  return load;
+  return { state: load, reason };
 }
 
 function calculatePvCurtailment(

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -30,6 +30,7 @@ export const simulationDataPointSchema = z.object({
   cost: z.number(),
   curtailment: z.number().default(0),
   loadState: z.boolean().default(false),
+  loadDecisionReason: z.string().default(''),
   batteryDecision: z.string().default('hold'),
   batteryDecisionReason: z.string().default(''),
 });
@@ -39,6 +40,7 @@ export const controlDecisionSchema = z.object({
   batteryPower: z.number(),
   curtailment: z.number().default(0),
   loadState: z.boolean().default(false),
+  loadDecisionReason: z.string().default(''),
   batteryDecision: z.string().default('hold'),
   batteryDecisionReason: z.string().default(''),
 });


### PR DESCRIPTION
## Summary
- show tooltips instantly
- rename Relay column to Load and add tooltip with decision reason
- track load decision reason in schemas and optimization algorithm
- include controllable load consumption in consumption totals
- adjust net power and PV generation calculations

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687a04d593bc833293062daaa772308e